### PR TITLE
Fix MCO index check in HAL_RCC_MCOConfig

### DIFF
--- a/Src/stm32wbxx_hal_rcc.c
+++ b/Src/stm32wbxx_hal_rcc.c
@@ -1351,7 +1351,7 @@ void HAL_RCC_MCOConfig(uint32_t RCC_MCOx, uint32_t RCC_MCOSource, uint32_t RCC_M
     /* Mask MCOSEL[] and MCOPRE[] bits then set MCO clock source and prescaler */
     LL_RCC_ConfigMCO(RCC_MCOSource, RCC_MCODiv);
   }
-  else if (RCC_MCOx == RCC_MCO2_INDEX)
+  else if (mcoindex == RCC_MCO2_INDEX)
   {
     assert_param(IS_RCC_MCODIV(RCC_MCODiv));
     assert_param(IS_RCC_MCO2SOURCE(RCC_MCOSource));
@@ -1359,7 +1359,7 @@ void HAL_RCC_MCOConfig(uint32_t RCC_MCOx, uint32_t RCC_MCOSource, uint32_t RCC_M
     LL_RCC_ConfigMCO(RCC_MCOSource, RCC_MCODiv);
   }
 #if defined(RCC_MCO3_SUPPORT)
-  else if (RCC_MCOx == RCC_MCO3_INDEX)
+  else if (mcoindex == RCC_MCO3_INDEX)
   {
     assert_param(IS_RCC_MCODIV(RCC_MCODiv));
     assert_param(IS_RCC_MCO3SOURCE(RCC_MCOSource));


### PR DESCRIPTION
MCOConfig did not check the MCO index properly meaning that outputting MCO signal to either MCO2 or MCO3 would fail without the user knowing it

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/stm32wbxx_hal_driver/blob/master/CONTRIBUTING.md) file.

